### PR TITLE
Feature/sql literal tag

### DIFF
--- a/__tests__/utils/sql_test.ts
+++ b/__tests__/utils/sql_test.ts
@@ -1,4 +1,4 @@
-import { SQL, SQLFragment } from "../../src/utils/sql";
+import { SQL, SQLFragment, SQLUnsafeRaw } from "../../src/utils/sql";
 
 describe("Utils", () => {
   describe("SQL utilities", () => {
@@ -29,6 +29,39 @@ describe("Utils", () => {
 
       it("does not return the variables interpolated", () => {
         expect(res).not.toEqual("SELECT * FROM example WHERE column = 10");
+      });
+    });
+
+    describe("for sql literals", () => {
+      const dynamic = "beep_boop";
+
+      it("returns a function", () => {
+        const sqlLit = SQLUnsafeRaw`${dynamic}`;
+
+        expect(sqlLit).toBeInstanceOf(Function);
+      });
+
+      it("...which returns the interpolated string", () => {
+        const sqlLit = SQLUnsafeRaw`${dynamic}`;
+
+        expect(sqlLit()).toEqual(`${dynamic}`);
+      });
+
+      describe("in statements", () => {
+        const statement = SQL`SELECT "${SQLUnsafeRaw`${dynamic}`}" FROM hello_world`;
+
+        it("returns the interpolated string", () => {
+          expect(statement.text).toEqual(`SELECT "${dynamic}" FROM hello_world`);
+        });
+      });
+
+      describe("in fragments", () => {
+        const fragment = SQLFragment`SELECT "${SQLUnsafeRaw`${dynamic}`}" FROM hello_world`;
+        const mockGen = jest.fn(v => (typeof v === "function" ? `${v()}` : `${v}`));
+
+        it("returns the interpolated string", () => {
+          expect(fragment(mockGen)).toEqual(`SELECT "${dynamic}" FROM hello_world`);
+        });
       });
     });
 
@@ -147,14 +180,14 @@ describe("Utils", () => {
           });
 
           it("matches populated arrays", () => {
-            value = {a: 10};
+            value = { a: 10 };
             res = SQL`${value} = ${value}`;
             expect(res).toHaveProperty("text", "$1 = $1");
             expect(res).toHaveProperty("values", [value]);
           });
 
           it("matches nested arrays", () => {
-            value = {a: {b: 10}};
+            value = { a: { b: 10 } };
             res = SQL`${value} = ${value}`;
             expect(res).toHaveProperty("text", "$1 = $1");
             expect(res).toHaveProperty("values", [value]);

--- a/__tests__/utils/sql_test.ts
+++ b/__tests__/utils/sql_test.ts
@@ -12,9 +12,9 @@ describe("Utils", () => {
 
       beforeEach(() => {
         let i = 0;
-        const seqGen = (value: any): number => {
+        const seqGen = (value: any): string => {
           i++;
-          return i;
+          return `$${i}`;
         };
         res = fragment(seqGen);
       });

--- a/src/utils/sql.ts
+++ b/src/utils/sql.ts
@@ -1,6 +1,6 @@
 import * as pg from "pg";
 
-type IndexGetter = (value: any) => number;
+type IndexGetter = (value: any) => string;
 
 export const SQLFragment = (parts: TemplateStringsArray, ...inValues: any[]) => (
   getValueIndex: IndexGetter,

--- a/src/utils/sql.ts
+++ b/src/utils/sql.ts
@@ -7,12 +7,18 @@ export const SQLFragment = (parts: TemplateStringsArray, ...inValues: any[]) => 
 ): string =>
   parts.reduce((prev, curr, valIdx) => `${prev}${getValueIndex(inValues[valIdx - 1])}${curr}`);
 
+export const SQLUnsafeRaw = (parts: TemplateStringsArray, ...inValues: string[]) => (..._: any[]) =>
+  parts.reduce((prev, curr, valIdx) => `${prev}${inValues[valIdx - 1]}${curr}`);
+
 export const SQL = (parts: TemplateStringsArray, ...inValues: any[]): pg.QueryConfig => {
   const outValues: any[] = [];
 
   const getValueIndex = (value: any): string => {
     if (value == null) {
       return `NULL`;
+    }
+    if (typeof value === "function") {
+      return `${value()}`;
     }
     const found = outValues.indexOf(value);
     if (found > -1) {


### PR DESCRIPTION
Allows using dynamic bits in SQL statements for things that can't be bound, allowing e.g. dynamic column names/lists.

Hostile naming to underline this is potentially unsafe, as there is no escaping and it can if misused allow for SQL injections.

Example

```
const dynamic = Math.random() > 0.5 ? "beep" : "boop";
const sqlConfig = SQL`SELECT ${SQLUnsafeRaw`${dynamic}`} FROM tbl`;
```